### PR TITLE
feat: add Barbora product search spike

### DIFF
--- a/docs/session-local-development.md
+++ b/docs/session-local-development.md
@@ -32,6 +32,14 @@ If the file is absent, `assertHasStorageState()` fails with instructions to run 
 
 v1 does **not** detect “still logged in.” If Barbora treats you as logged out, **run `npm run session:bootstrap` again** and overwrite the file.
 
+## Search spike (manual)
+
+To exercise Barbora product search and print structured candidates (no cart/checkout):
+
+`npm run spike:search -- --query "piens" --top 5`
+
+Uses the same optional storage state as above. Add `--headed` to watch the browser; add `--json` for machine-readable output.
+
 ## Payment
 
 Session reuse does **not** change the product rule: **never** automate payment. Checkout and payment stay manual on Barbora.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "playwright:install": "playwright install",
-    "session:bootstrap": "npx tsx scripts/bootstrap-barbora-session.ts"
+    "session:bootstrap": "npx tsx scripts/bootstrap-barbora-session.ts",
+    "spike:search": "npx tsx scripts/search-spike.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.0",

--- a/scripts/search-spike.ts
+++ b/scripts/search-spike.ts
@@ -1,0 +1,116 @@
+import { chromium } from '@playwright/test';
+
+import { runBarboraSearchAndCollect } from '../src/executor/barboraSearchSpike';
+import type { SearchCandidate } from '../src/executor/searchCandidate';
+import { hasStorageState, storageStateContextOptions } from '../src/session/storageState';
+
+function parseArgs(argv: string[]): {
+  query: string;
+  top: number;
+  headed: boolean;
+  json: boolean;
+} {
+  let query = '';
+  let top = 10;
+  let headed = false;
+  let json = false;
+  const rest = [...argv];
+  while (rest.length > 0) {
+    const a = rest.shift()!;
+    if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (a === '--query' || a === '-q') {
+      query = (rest.shift() ?? '').trim();
+      continue;
+    }
+    if (a === '--top' || a === '-n') {
+      top = Math.max(1, parseInt(rest.shift() ?? '10', 10) || 10);
+      continue;
+    }
+    if (a === '--headed') {
+      headed = true;
+      continue;
+    }
+    if (a === '--json') {
+      json = true;
+      continue;
+    }
+    if (!a.startsWith('-') && !query) {
+      query = a.trim();
+      continue;
+    }
+    console.error(`Unknown argument: ${a}`);
+    printHelp();
+    process.exit(1);
+  }
+  return { query, top, headed, json };
+}
+
+function printHelp(): void {
+  console.log(`Usage: npx tsx scripts/search-spike.ts [options] "<query>"
+
+Options:
+  -q, --query <text>   Search string (Latvian ok)
+  -n, --top <n>        Max results to print (default 10)
+      --headed         Show browser window
+      --json           Print JSON instead of text table
+  -h, --help           This message
+
+Positional query is accepted if it is the first non-flag argument.
+`);
+}
+
+function printHuman(query: string, candidates: SearchCandidate[]): void {
+  console.log(`Query: ${query}`);
+  console.log(`Results (showing ${candidates.length}):`);
+  console.log('');
+  for (const c of candidates) {
+    console.log(`--- #${c.index} ---`);
+    console.log(`title:       ${c.title}`);
+    console.log(`url:         ${c.productUrl ?? '(none)'}`);
+    console.log(`price:       ${c.priceText ?? '(unknown)'}`);
+    console.log(`unit/pack:   ${c.packSizeText ?? '(unknown)'}`);
+    console.log('');
+  }
+}
+
+async function main(): Promise<void> {
+  const { query, top, headed, json } = parseArgs(process.argv.slice(2));
+  if (!query) {
+    console.error('Missing search query. Use --query "<text>" or pass it as the first argument.');
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (hasStorageState()) {
+    console.log('Using saved Barbora session (.auth / BARBORA_STORAGE_STATE_PATH).');
+  } else {
+    console.log('No saved session file; continuing as anonymous (search may still work).');
+  }
+
+  const browser = await chromium.launch({ headless: !headed });
+  const context = await browser.newContext({
+    ...storageStateContextOptions(),
+    viewport: { width: 1400, height: 900 },
+  });
+  const page = await context.newPage();
+
+  try {
+    const candidates = await runBarboraSearchAndCollect(page, { query, topN: top });
+    if (json) {
+      console.log(JSON.stringify({ query, count: candidates.length, candidates }, null, 2));
+    } else {
+      printHuman(query, candidates);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/src/executor/barboraSearchSpike.ts
+++ b/src/executor/barboraSearchSpike.ts
@@ -1,0 +1,125 @@
+/**
+ * Barbora.lv search spike — DOM assumptions (fragile, verify after site updates):
+ * - Desktop layout: visible search field is the last duplicate `#fti-search` (two nodes exist; first is hidden).
+ * - Results: product tiles use `.product-card-next`; each has `a[href^="/produkti/"]` and an `img[alt]` title.
+ * - Cookie banner: optional `#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll`.
+ * Waits use URL + visible tiles, not networkidle.
+ */
+
+import type { Page } from '@playwright/test';
+
+import type { SearchCandidate } from './searchCandidate';
+
+const ERR = '[barbora-search-spike]';
+
+const BARBORA_ORIGIN = 'https://www.barbora.lv';
+const COOKIE_ALLOW = '#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll';
+/** Prefer last matching input — Barbora renders a hidden duplicate for mobile/other layout. */
+const SEARCH_INPUT = '#fti-search';
+const RESULT_CARD = '.product-card-next';
+const NAV_TIMEOUT_MS = 45_000;
+const RESULTS_TIMEOUT_MS = 45_000;
+
+export interface RunBarboraSearchOptions {
+  query: string;
+  topN: number;
+}
+
+function toAbsoluteUrl(origin: string, href: string | null): string | null {
+  if (!href) return null;
+  if (href.startsWith('http')) return href;
+  const base = origin.replace(/\/$/, '');
+  return href.startsWith('/') ? `${base}${href}` : `${base}/${href}`;
+}
+
+/** Pull €-bearing snippets from card text; shelf price usually has no "/"; unit price has €/kg, €/l, etc. */
+function splitPriceHints(cardText: string): { priceText: string | null; packSizeText: string | null } {
+  // Barbora splits digits and € across lines in innerText; strip whitespace before matching.
+  const compact = cardText.replace(/\s+/g, '');
+  // Unit after € is short letters (lv/ru), e.g. €/l or €/л; {1,4} avoids eating "Pievienot".
+  const priceToken = /\d+[.,]\d+€(?:\/\p{L}{1,4})?/giu;
+  const matches = [...compact.matchAll(priceToken)].map((m) => m[0]);
+  if (matches.length === 0) return { priceText: null, packSizeText: null };
+  const perUnit = matches.filter((m) => m.includes('/'));
+  const shelf = matches.filter((m) => !m.includes('/'));
+  const priceText = shelf[0] ?? matches[0] ?? null;
+  const packSizeText = perUnit[0] ?? null;
+  return { priceText, packSizeText };
+}
+
+export async function runBarboraSearchAndCollect(
+  page: Page,
+  options: RunBarboraSearchOptions,
+): Promise<SearchCandidate[]> {
+  const { query, topN } = options;
+  if (!query.trim()) {
+    throw new Error(`${ERR} search query is empty`);
+  }
+
+  await page.goto(`${BARBORA_ORIGIN}/`, {
+    waitUntil: 'domcontentloaded',
+    timeout: NAV_TIMEOUT_MS,
+  });
+
+  const cookieBtn = page.locator(COOKIE_ALLOW);
+  if (await cookieBtn.isVisible().catch(() => false)) {
+    await cookieBtn.click();
+    await page.locator(SEARCH_INPUT).last().waitFor({ state: 'visible', timeout: 10_000 });
+  }
+
+  const search = page.locator(SEARCH_INPUT).last();
+  await search.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {
+    throw new Error(
+      `${ERR} search field not visible (selector ${SEARCH_INPUT}). URL: ${page.url()}`,
+    );
+  });
+
+  await search.fill(query);
+  await search.press('Enter');
+
+  await page.waitForURL(/meklet/i, { timeout: NAV_TIMEOUT_MS }).catch(() => {
+    throw new Error(
+      `${ERR} expected navigation to search URL (/meklet/) after submit. Current URL: ${page.url()}`,
+    );
+  });
+
+  const origin = new URL(page.url()).origin;
+
+  const cards = page.locator(RESULT_CARD);
+  await cards
+    .first()
+    .waitFor({ state: 'visible', timeout: RESULTS_TIMEOUT_MS })
+    .catch(() => {
+      throw new Error(
+        `${ERR} no visible product tiles (${RESULT_CARD}) after search. URL: ${page.url()}`,
+      );
+    });
+
+  const count = await cards.count();
+  const limit = Math.min(topN, count);
+  const out: SearchCandidate[] = [];
+
+  for (let i = 0; i < limit; i++) {
+    const card = cards.nth(i);
+    const link = card.locator('a[href^="/produkti/"]').first();
+    const href = (await link.count()) > 0 ? await link.getAttribute('href') : null;
+    const img = card.locator('img[alt]').first();
+    const title =
+      (await img.count()) > 0
+        ? ((await img.getAttribute('alt')) ?? '').trim()
+        : ((await link.innerText().catch(() => '')) ?? '').trim();
+
+    const rawText = (await card.innerText()).replace(/\s+/g, ' ').trim();
+    const { priceText, packSizeText } = splitPriceHints(rawText);
+
+    out.push({
+      index: i + 1,
+      title: title || '(no title)',
+      productUrl: toAbsoluteUrl(origin, href),
+      priceText,
+      packSizeText,
+    });
+  }
+
+  return out;
+}

--- a/src/executor/searchCandidate.ts
+++ b/src/executor/searchCandidate.ts
@@ -1,0 +1,16 @@
+/**
+ * Plain search-result row for inspection and future resolver input.
+ * Populated by Barbora executor automation only — keep free of Playwright types.
+ */
+export interface SearchCandidate {
+  /** 1-based index in the extracted list */
+  index: number;
+  /** Product title as shown (often from image alt on listing cards) */
+  title: string;
+  /** Absolute HTTPS URL to the product page, if a /produkti/ link exists */
+  productUrl: string | null;
+  /** Primary shelf price text when detectable (e.g. "1.49€") */
+  priceText: string | null;
+  /** Unit price or pack hint when detectable (e.g. "0,99€/l"); optional */
+  packSizeText: string | null;
+}


### PR DESCRIPTION
## What changed
- Added a serializable `SearchCandidate` type for search results
- Added a focused Barbora search spike implementation under the executor area
- Added a CLI script for running manual product search spikes
- Added an npm script for the search spike
- Added a short manual search-spike note to session/local development docs

## Why
This validates that Barbora product search can be executed and that structured candidate data can be extracted in a deterministic, inspectable way.

## Notes
- This is a manual spike, not a production search feature
- No add-to-cart, checkout, payment, or matching/ranking logic is implemented
- The spike is session-aware when local storage state exists, but does not require login
- Selector and price parsing assumptions remain local to the spike and may need adjustment if Barbora markup changes
