### PR TITLE
feat: add Barbora add-to-cart spike

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:headed": "playwright test --headed",
     "playwright:install": "playwright install",
     "session:bootstrap": "npx tsx scripts/bootstrap-barbora-session.ts",
-    "spike:search": "npx tsx scripts/search-spike.ts"
+    "spike:search": "npx tsx scripts/search-spike.ts",
+    "spike:add-to-cart": "npx tsx scripts/add-to-cart-spike.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.0",

--- a/scripts/add-to-cart-spike.ts
+++ b/scripts/add-to-cart-spike.ts
@@ -1,0 +1,153 @@
+import { chromium } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+import { runBarboraAddToCartSpike } from '../src/executor/barboraAddToCartSpike';
+import { runBarboraSearchAndCollect } from '../src/executor/barboraSearchSpike';
+import { hasStorageState, storageStateContextOptions } from '../src/session/storageState';
+
+function parseArgs(argv: string[]): {
+  url: string;
+  query: string;
+  pick: number;
+  headed: boolean;
+  json: boolean;
+} {
+  let url = '';
+  let query = '';
+  let pick = 1;
+  let headed = false;
+  let json = false;
+  const rest = [...argv];
+  while (rest.length > 0) {
+    const a = rest.shift()!;
+    if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (a === '--url' || a === '-u') {
+      url = (rest.shift() ?? '').trim();
+      continue;
+    }
+    if (a === '--query' || a === '-q') {
+      query = (rest.shift() ?? '').trim();
+      continue;
+    }
+    if (a === '--pick' || a === '-p') {
+      pick = Math.max(1, parseInt(rest.shift() ?? '1', 10) || 1);
+      continue;
+    }
+    if (a === '--headed') {
+      headed = true;
+      continue;
+    }
+    if (a === '--json') {
+      json = true;
+      continue;
+    }
+    console.error(`Unknown argument: ${a}`);
+    printHelp();
+    process.exit(1);
+  }
+  return { url, query, pick, headed, json };
+}
+
+function printHelp(): void {
+  console.log(`Usage: npx tsx scripts/add-to-cart-spike.ts [options]
+
+Primary path (most reliable):
+  -u, --url <https://...>   Full https URL of a Barbora product page (barbora.lv or www.barbora.lv).
+
+Convenience path:
+  -q, --query <text>        Search string; use with --pick
+  -p, --pick <n>            1-based index from search results (default 1)
+
+Options:
+      --headed              Show browser window
+      --json                Print JSON summary to stdout
+  -h, --help                This message
+
+Examples:
+  npm run spike:add-to-cart -- --url "https://www.barbora.lv/produkti/some-product" --headed
+  npm run spike:add-to-cart -- --query "piens" --pick 1
+
+Session: uses .auth/barbora-storage-state.json when present (see npm run session:bootstrap).
+`);
+}
+
+async function resolveProductUrlFromSearch(page: Page, query: string, pick: number): Promise<string> {
+  if (!query.trim()) {
+    throw new Error(
+      '[add-to-cart-spike] missing --query for search mode. Provide --url <https://...> (recommended) or --query with --pick.',
+    );
+  }
+  const candidates = await runBarboraSearchAndCollect(page, { query, topN: Math.max(pick, 10) });
+  const chosen = candidates.find((c) => c.index === pick);
+  if (!chosen) {
+    throw new Error(
+      `[add-to-cart-spike] pick out of range: --pick ${pick} but only ${candidates.length} result(s) collected. Increase search coverage or lower --pick.`,
+    );
+  }
+  if (!chosen.productUrl) {
+    throw new Error(
+      `[add-to-cart-spike] missing product URL for search result #${pick} ("${chosen.title}"). No /produkti/ link on that card — use --url with a direct product page instead.`,
+    );
+  }
+  return chosen.productUrl;
+}
+
+async function main(): Promise<void> {
+  const { url, query, pick, headed, json } = parseArgs(process.argv.slice(2));
+
+  if (!url && !query) {
+    console.error(
+      '[add-to-cart-spike] missing input: provide --url <https://...> (primary) or --query "<text>" with optional --pick (convenience).',
+    );
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (hasStorageState()) {
+    console.log('Using saved Barbora session (.auth / BARBORA_STORAGE_STATE_PATH).');
+  } else {
+    console.log('No saved session file; continuing as anonymous (add-to-cart may still work).');
+  }
+
+  const browser = await chromium.launch({ headless: !headed });
+  const context = await browser.newContext({
+    ...storageStateContextOptions(),
+    viewport: { width: 1400, height: 900 },
+  });
+  const page = await context.newPage();
+
+  try {
+    let productUrl = url.trim();
+    if (!productUrl) {
+      console.log(`Resolving product URL from search: query="${query}" pick=${pick} …`);
+      productUrl = await resolveProductUrlFromSearch(page, query, pick);
+      console.log(`Using product URL: ${productUrl}`);
+    } else {
+      console.log(`Using product URL (--url): ${productUrl}`);
+    }
+
+    const result = await runBarboraAddToCartSpike(page, { productUrl });
+
+    if (json) {
+      console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+    } else {
+      console.log('');
+      console.log('beforeSignal:', result.beforeSignal);
+      console.log('afterSignal: ', result.afterSignal);
+      console.log('message:    ', result.message);
+      console.log('');
+      console.log('OK — cart signal indicates the product was added.');
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/src/executor/barboraAddToCartSpike.ts
+++ b/src/executor/barboraAddToCartSpike.ts
@@ -1,0 +1,200 @@
+/**
+ * Barbora.lv add-to-cart spike — DOM assumptions (fragile, verify after site updates):
+ * - Cookie banner: `#CybotCookiebotDialog` with either `#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll`
+ *   or role button name matching /Atļaut visus sīkfailus/i.
+ * - Cart verification signal: `button.b-cart-in-header--btn` with a price-like label; Barbora may render two nodes (e.g. mobile/desktop) — use **.last()** so the visible header instance is used.
+ * - Add to cart: primary `button` in `main` with accessible name matching Latvian / Russian / English
+ *   add phrases (e.g. "В корзину", "Pievienot grozam").
+ * Success rule (explicit, not strict +1): header cart text changed, or empty/zero-total → non-zero-total,
+ * or parsed € amount increased. Uses before/after reads; avoids networkidle.
+ */
+
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const ERR = '[barbora-add-to-cart-spike]';
+
+const NAV_TIMEOUT_MS = 60_000;
+const COOKIE_DIALOG = '#CybotCookiebotDialog';
+const COOKIE_OPTIN_ALLOW = '#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll';
+/** Locales observed on barbora.lv PDPs */
+const ADD_TO_CART_NAME_RE =
+  /Pievienot(\s+grozam)?|В корзину|Добавить в корзину|Add to cart/i;
+
+export interface RunBarboraAddToCartOptions {
+  productUrl: string;
+}
+
+export interface AddToCartSpikeResult {
+  productUrl: string;
+  beforeSignal: string;
+  afterSignal: string;
+  message: string;
+}
+
+function assertValidBarboraProductUrl(url: string): void {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    throw new Error(
+      `${ERR} missing product URL. Pass a full https URL to a Barbora product page (path under /produkti/ or equivalent), e.g. https://www.barbora.lv/produkti/....`,
+    );
+  }
+  let u: URL;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    throw new Error(`${ERR} invalid product URL (not a valid URL string): ${url.slice(0, 200)}`);
+  }
+  if (u.protocol !== 'https:') {
+    throw new Error(
+      `${ERR} invalid Barbora product URL: only https is supported. Got ${u.protocol}//${u.host}. Use https://www.barbora.lv/... or https://barbora.lv/....`,
+    );
+  }
+  const host = u.hostname.toLowerCase();
+  if (host !== 'barbora.lv' && host !== 'www.barbora.lv') {
+    throw new Error(
+      `${ERR} invalid Barbora product URL: hostname must be barbora.lv or www.barbora.lv. Got: ${u.hostname}`,
+    );
+  }
+}
+
+async function dismissCookieBannerIfPresent(page: Page): Promise<void> {
+  const dialog = page.locator(COOKIE_DIALOG);
+  const optin = page.locator(COOKIE_OPTIN_ALLOW);
+  const lvAllow = page.getByRole('button', { name: /Atļaut visus sīkfailus/i });
+
+  const dialogShown = await dialog.isVisible().catch(() => false);
+  const optinShown = await optin.isVisible().catch(() => false);
+  const lvShown = await lvAllow.isVisible().catch(() => false);
+  if (!dialogShown && !optinShown && !lvShown) {
+    return;
+  }
+
+  if (optinShown) {
+    await optin.click();
+  } else if (lvShown) {
+    await lvAllow.click();
+  } else {
+    await optin.click({ timeout: 5000 }).catch(async () => {
+      await lvAllow.click({ timeout: 5000 });
+    });
+  }
+
+  await dialog.waitFor({ state: 'hidden', timeout: 25_000 }).catch(() => {
+    throw new Error(
+      `${ERR} cookie banner still visible after accept attempt. Dismiss selectors: ${COOKIE_OPTIN_ALLOW} or role button /Atļaut visus sīkfailus/i. URL: ${page.url()}`,
+    );
+  });
+}
+
+/** Header cart total: `.last()` prefers the visible duplicate when Barbora renders hidden + visible header controls. */
+function cartHeaderLocator(page: Page) {
+  return page.locator('button.b-cart-in-header--btn').filter({ hasText: /\d+[.,]\d+/ }).last();
+}
+
+function normalizeSignalText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/** First amount like 1,49€ or 0,00 € in the string; null if none. */
+function parseFirstEuroAmount(text: string): number | null {
+  const m = normalizeSignalText(text).match(/(\d+)[.,](\d+)\s*€/i);
+  if (!m) return null;
+  return parseFloat(`${m[1]}.${m[2]}`);
+}
+
+/**
+ * Practical success: signal changed, or went from zero-total to non-zero display, or € amount increased.
+ * Not limited to “count +1”.
+ */
+function cartAddAppearsSuccessful(before: string, after: string): boolean {
+  const b = normalizeSignalText(before);
+  const a = normalizeSignalText(after);
+  if (b === a) {
+    const nb = parseFirstEuroAmount(b);
+    const na = parseFirstEuroAmount(a);
+    if (nb !== null && na !== null && na > nb) return true;
+    return false;
+  }
+  const zeroish = /^0[,.]00\s*€\s*$/i;
+  if (zeroish.test(b) && a.length > 0 && !zeroish.test(a)) return true;
+  return true;
+}
+
+export async function runBarboraAddToCartSpike(
+  page: Page,
+  options: RunBarboraAddToCartOptions,
+): Promise<AddToCartSpikeResult> {
+  const productUrl = options.productUrl.trim();
+  assertValidBarboraProductUrl(productUrl);
+
+  await page.goto(productUrl, {
+    waitUntil: 'domcontentloaded',
+    timeout: NAV_TIMEOUT_MS,
+  });
+
+  // Cookie dialog often mounts shortly after domcontentloaded; wait briefly then dismiss (retry once if it appears late).
+  await page.waitForTimeout(1500);
+  await dismissCookieBannerIfPresent(page);
+  await page.waitForTimeout(800);
+  await dismissCookieBannerIfPresent(page);
+
+  const cartLoc = cartHeaderLocator(page);
+  await cartLoc.waitFor({ state: 'visible', timeout: 20_000 })
+    .catch(() => {
+      throw new Error(
+        `${ERR} cart signal not found: no visible button.b-cart-in-header--btn with a price-like label (e.g. 0,00 €). Cannot verify cart changes. URL: ${page.url()}`,
+      );
+    });
+
+  const beforeSignal = normalizeSignalText(await cartLoc.innerText());
+
+  const inMain = page.locator('main').getByRole('button', { name: ADD_TO_CART_NAME_RE }).first();
+  await inMain.waitFor({ state: 'visible', timeout: 8_000 }).catch(() => {});
+  const addBtn = (await inMain.isVisible().catch(() => false))
+    ? inMain
+    : page.getByRole('button', { name: ADD_TO_CART_NAME_RE }).first();
+
+  await addBtn.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {
+    throw new Error(
+      `${ERR} add-to-cart button not found. Tried: main.getByRole('button', { name: /Pievienot|В корзину|Add to cart/i }) then the same globally. Update ADD_TO_CART_NAME_RE or DOM scope if the site changed. URL: ${page.url()}`,
+    );
+  });
+
+  await addBtn.click();
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          const t = normalizeSignalText(await cartLoc.innerText());
+          return cartAddAppearsSuccessful(beforeSignal, t);
+        },
+        {
+          timeout: 25_000,
+          intervals: [150, 300, 500],
+        },
+      )
+      .toBe(true);
+  } catch {
+    const afterFail = normalizeSignalText(await cartLoc.innerText().catch(() => ''));
+    throw new Error(
+      `${ERR} cart state unchanged after add (success rule: signal text changed, zero-total → non-zero, or € amount increased). before="${beforeSignal}" after="${afterFail}". URL: ${page.url()}`,
+    );
+  }
+
+  const afterSignal = normalizeSignalText(await cartLoc.innerText());
+
+  if (!cartAddAppearsSuccessful(beforeSignal, afterSignal)) {
+    throw new Error(
+      `${ERR} cart state unchanged after add (final check). before="${beforeSignal}" after="${afterSignal}". URL: ${page.url()}`,
+    );
+  }
+
+  return {
+    productUrl,
+    beforeSignal,
+    afterSignal,
+    message: 'Add-to-cart succeeded per header cart signal rule.',
+  };
+}


### PR DESCRIPTION
## What changed
- Added a focused Barbora add-to-cart spike implementation
- Added a manual CLI script for add-to-cart spike runs
- Added an npm script for running the add-to-cart spike

## Why
This validates that a single selected Barbora product can be added to the cart and that cart state change can be detected in a repeatable, inspectable way.

## Notes
- This is a manual spike, not a production cart feature
- The primary path uses a direct product page URL
- `--query + --pick` is supported as a convenience flow
- No checkout or payment behavior is implemented
- Cart verification is based on visible cart-state change, not a strict `+1` rule
