### PR TITLE
feat: add first orchestrated cart-prep run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Local Playwright storage state (cookies / localStorage); never commit.
 .auth/
 
+shopping.txt
+
 node_modules/
 .auth/
 playwright-report/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "session:bootstrap": "npx tsx scripts/bootstrap-barbora-session.ts",
     "spike:search": "npx tsx scripts/search-spike.ts",
     "spike:add-to-cart": "npx tsx scripts/add-to-cart-spike.ts",
-    "spike:checkout-handoff": "npx tsx scripts/checkout-handoff-spike.ts"
+    "spike:checkout-handoff": "npx tsx scripts/checkout-handoff-spike.ts",
+    "run:cart-prep": "npx tsx scripts/cart-prep-run.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.0",

--- a/scripts/cart-prep-run.ts
+++ b/scripts/cart-prep-run.ts
@@ -1,0 +1,179 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { chromium } from '@playwright/test';
+
+import { runCartPrepRun, type CartPrepInputLine } from '../src/run/cartPrepRun';
+import { formatRunSummaryHuman } from '../src/run/formatRunSummary';
+import { hasStorageState, storageStateContextOptions } from '../src/session/storageState';
+
+function parseArgs(argv: string[]): {
+  queries: string[];
+  filePath: string;
+  pick: number;
+  topN: number;
+  handoff: boolean;
+  headed: boolean;
+  json: boolean;
+} {
+  const queries: string[] = [];
+  let filePath = '';
+  let pick = 1;
+  let topN = 10;
+  let handoff = false;
+  let headed = false;
+  let json = false;
+  const rest = [...argv];
+  while (rest.length > 0) {
+    const a = rest.shift()!;
+    if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (a === '--file' || a === '-f') {
+      filePath = (rest.shift() ?? '').trim();
+      continue;
+    }
+    if (a === '--query' || a === '-q') {
+      queries.push((rest.shift() ?? '').trim());
+      continue;
+    }
+    if (a === '--pick' || a === '-p') {
+      pick = Math.max(1, parseInt(rest.shift() ?? '1', 10) || 1);
+      continue;
+    }
+    if (a === '--top' || a === '-n') {
+      topN = Math.max(1, parseInt(rest.shift() ?? '10', 10) || 10);
+      continue;
+    }
+    if (a === '--handoff') {
+      handoff = true;
+      continue;
+    }
+    if (a === '--headed') {
+      headed = true;
+      continue;
+    }
+    if (a === '--json') {
+      json = true;
+      continue;
+    }
+    console.error(`Unknown argument: ${a}`);
+    printHelp();
+    process.exit(1);
+  }
+  return { queries, filePath, pick, topN, handoff, headed, json };
+}
+
+function printHelp(): void {
+  console.log(`Usage: npx tsx scripts/cart-prep-run.ts [options]
+
+Orchestrated cart-prep (MVP): for each line, search Barbora, take result #--pick, add to cart.
+Checkout handoff is optional and off by default (no payment automation).
+
+Input (combine as needed):
+  -q, --query <text>   Search string (repeat for multiple items; processed first, in order)
+  -f, --file <path>    UTF-8 file, one non-empty trimmed line per search query (after -q lines)
+
+Options:
+  -p, --pick <n>       1-based search result index (default 1)
+  -n, --top <n>        Max SERP cards to read (default 10; internally at least max(top, pick))
+      --handoff        After all lines, navigate toward checkout (still stops before payment)
+      --headed         Show browser window
+      --json           Print RunResultSummary JSON to stdout
+  -h, --help           This message
+
+Exit codes:
+  0 — Run finished (including lines skipped or review_needed; see summary).
+  1 — Fatal: bad args, missing input, I/O error, or unexpected crash before summary.
+
+Examples:
+  npm run run:cart-prep -- -q "piens" -q "maize"
+  npm run run:cart-prep -- --file shopping.txt --headed
+  npm run run:cart-prep -- --file shopping.txt --handoff --json
+
+Session: uses .auth/barbora-storage-state.json when present (see npm run session:bootstrap).
+`);
+}
+
+function loadQueriesFromFile(filePath: string): string[] {
+  const resolved = path.resolve(process.cwd(), filePath);
+  const raw = fs.readFileSync(resolved, 'utf8');
+  return raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function buildInputLines(queriesFromFlags: string[], fileQueries: string[]): CartPrepInputLine[] {
+  const all = [...queriesFromFlags, ...fileQueries];
+  return all.map((query, i) => ({ lineId: String(i + 1), query }));
+}
+
+async function main(): Promise<void> {
+  const { queries, filePath, pick, topN, handoff, headed, json } = parseArgs(process.argv.slice(2));
+
+  let fileQueries: string[] = [];
+  if (filePath) {
+    try {
+      fileQueries = loadQueriesFromFile(filePath);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[cart-prep-run] cannot read --file: ${msg}`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  const inputLines = buildInputLines(queries, fileQueries);
+  if (inputLines.length === 0) {
+    if (filePath) {
+      const resolved = path.resolve(process.cwd(), filePath);
+      console.error(
+        `[cart-prep-run] no shopping lines after reading --file (${resolved}). ` +
+          'The file must contain at least one non-empty line (whitespace-only lines are ignored). Save the file and ensure it is UTF-8 text.',
+      );
+    } else {
+      console.error(
+        '[cart-prep-run] no shopping lines: pass -q/--query and/or --file with non-empty lines.',
+      );
+    }
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (hasStorageState()) {
+    console.log('Using saved Barbora session (.auth / BARBORA_STORAGE_STATE_PATH).');
+  } else {
+    console.log('No saved session file; continuing as anonymous (checkout handoff may require login).');
+  }
+
+  const browser = await chromium.launch({ headless: !headed });
+  const context = await browser.newContext({
+    ...storageStateContextOptions(),
+    viewport: { width: 1400, height: 900 },
+  });
+  const page = await context.newPage();
+
+  try {
+    const summary = await runCartPrepRun(page, inputLines, {
+      pick,
+      topN,
+      attemptHandoff: handoff,
+    });
+
+    if (json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      console.log(formatRunSummaryHuman(summary));
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/src/run/cartPrepRun.ts
+++ b/src/run/cartPrepRun.ts
@@ -1,0 +1,119 @@
+import type { Page } from '@playwright/test';
+
+import { runBarboraAddToCartSpike } from '../executor/barboraAddToCartSpike';
+import { runBarboraCheckoutHandoffSpike } from '../executor/barboraCheckoutHandoffSpike';
+import { runBarboraSearchAndCollect } from '../executor/barboraSearchSpike';
+import type { RunLineResult, RunResultSummary } from './runTypes';
+
+export interface CartPrepInputLine {
+  /** 1-based id as string, e.g. "1", "2" */
+  lineId: string;
+  /** Search query for this line */
+  query: string;
+}
+
+export interface CartPrepRunOptions {
+  /** 1-based index into collected search results (same semantics as spike scripts). */
+  pick: number;
+  /** Upper bound for how many result cards to read from the SERP. */
+  topN: number;
+  /** If true, run checkout handoff after all lines (still no payment). */
+  attemptHandoff: boolean;
+}
+
+const SEARCH_ERR = '[barbora-search-spike]';
+
+function makeRunId(): string {
+  return `run-${new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, -5)}`;
+}
+
+function outcomeFromSearchFailure(message: string): RunLineResult['outcome'] {
+  return message.includes(SEARCH_ERR) ? 'review_needed' : 'skipped';
+}
+
+/**
+ * Sequential cart prep: search → pick by index → add. Optional checkout handoff at the end.
+ */
+export async function runCartPrepRun(
+  page: Page,
+  inputLines: CartPrepInputLine[],
+  options: CartPrepRunOptions,
+): Promise<RunResultSummary> {
+  const lineResults: RunLineResult[] = [];
+  const topN = Math.max(1, options.topN, options.pick);
+
+  for (const line of inputLines) {
+    const q = line.query.trim();
+    if (!q) {
+      lineResults.push({
+        lineId: line.lineId,
+        outcome: 'skipped',
+        userMessage: 'Empty search query for this line.',
+      });
+      continue;
+    }
+
+    try {
+      const candidates = await runBarboraSearchAndCollect(page, { query: q, topN });
+      // Naive rule (temporary): 1-based `--pick` matches spike scripts. Replace with resolver later.
+      const rowAtPick = candidates.find((c) => c.index === options.pick);
+      if (!rowAtPick) {
+        lineResults.push({
+          lineId: line.lineId,
+          outcome: 'review_needed',
+          userMessage: `Not enough search results for pick=${options.pick} (got ${candidates.length}). Try a different query or lower --pick.`,
+        });
+        continue;
+      }
+      if (!rowAtPick.productUrl) {
+        lineResults.push({
+          lineId: line.lineId,
+          outcome: 'review_needed',
+          userMessage: `Search result #${options.pick} has no product link ("${rowAtPick.title}"). Pick a product on Barbora or use a direct URL in a future flow.`,
+        });
+        continue;
+      }
+
+      const addResult = await runBarboraAddToCartSpike(page, { productUrl: rowAtPick.productUrl });
+      lineResults.push({
+        lineId: line.lineId,
+        outcome: 'added',
+        barboraLabel: rowAtPick.title,
+        quantityAdded: 1,
+        userMessage: addResult.message,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      lineResults.push({
+        lineId: line.lineId,
+        outcome: outcomeFromSearchFailure(msg),
+        userMessage: msg,
+      });
+    }
+  }
+
+  let checkoutHandoffReached = false;
+  let handoffMessage: string | undefined;
+
+  if (options.attemptHandoff) {
+    try {
+      const handoff = await runBarboraCheckoutHandoffSpike(page);
+      checkoutHandoffReached = handoff.handoffReached;
+      handoffMessage = handoff.message;
+    } catch (e) {
+      checkoutHandoffReached = false;
+      handoffMessage = e instanceof Error ? e.message : String(e);
+    }
+  } else {
+    checkoutHandoffReached = false;
+    handoffMessage =
+      'Checkout handoff was not requested. Pass --handoff to navigate to checkout after the run.';
+  }
+
+  return {
+    runId: makeRunId(),
+    lines: lineResults,
+    checkoutHandoffReached,
+    handoffMessage,
+  };
+}

--- a/src/run/formatRunSummary.ts
+++ b/src/run/formatRunSummary.ts
@@ -1,0 +1,64 @@
+import type { RunLineResult, RunResultSummary } from './runTypes';
+
+function lineIdSortKey(lineId: string): number {
+  const n = parseInt(lineId, 10);
+  return Number.isFinite(n) ? n : Number.MAX_SAFE_INTEGER;
+}
+
+function sortLinesByLineId(lines: RunLineResult[]): RunLineResult[] {
+  return [...lines].sort((a, b) => lineIdSortKey(a.lineId) - lineIdSortKey(b.lineId));
+}
+
+/**
+ * Human-oriented summary per docs/specs/run-summary.md (minimum sections).
+ */
+export function formatRunSummaryHuman(summary: RunResultSummary): string {
+  const lines: string[] = [];
+  const handoffYesNo = summary.checkoutHandoffReached ? 'yes' : 'no';
+
+  if (summary.runId) {
+    lines.push(`Run: ${summary.runId}`);
+  }
+  lines.push(`Checkout handoff: ${handoffYesNo}`);
+  lines.push('');
+
+  const sorted = sortLinesByLineId(summary.lines);
+  const needsAttention = sorted.filter((l) => l.outcome === 'review_needed');
+  if (needsAttention.length > 0) {
+    lines.push(`Needs attention (${needsAttention.length} line(s)):`);
+    for (const line of needsAttention) {
+      lines.push(formatLineBlock(line));
+    }
+    lines.push('');
+  }
+
+  const others = sorted.filter((l) => l.outcome !== 'review_needed');
+  if (others.length > 0) {
+    lines.push('Line outcomes:');
+    for (const line of others) {
+      lines.push(formatLineBlock(line));
+    }
+    lines.push('');
+  }
+
+  if (!summary.checkoutHandoffReached && summary.handoffMessage?.trim()) {
+    lines.push('Handoff note:');
+    lines.push(`  ${summary.handoffMessage.trim()}`);
+  }
+
+  return lines.join('\n').replace(/\n+$/, '') + '\n';
+}
+
+function formatLineBlock(line: RunLineResult): string {
+  const parts: string[] = [];
+  parts.push(`  lineId: ${line.lineId}`);
+  parts.push(`    outcome: ${line.outcome}`);
+  if (line.barboraLabel != null && line.barboraLabel !== '') {
+    parts.push(`    barboraLabel: ${line.barboraLabel}`);
+  }
+  if (line.quantityAdded != null) {
+    parts.push(`    quantityAdded: ${line.quantityAdded}`);
+  }
+  parts.push(`    userMessage: ${line.userMessage}`);
+  return parts.join('\n');
+}

--- a/src/run/runTypes.ts
+++ b/src/run/runTypes.ts
@@ -1,0 +1,22 @@
+/**
+ * Run result types for orchestrated cart-prep (MVP vertical slice).
+ * Aligns with docs/specs/data-model.md §5 and docs/specs/run-summary.md.
+ * This slice emits only added | skipped | review_needed (no substituted until real substitution exists).
+ */
+
+export type LineOutcome = 'added' | 'skipped' | 'review_needed';
+
+export interface RunLineResult {
+  lineId: string;
+  outcome: LineOutcome;
+  userMessage: string;
+  barboraLabel?: string;
+  quantityAdded?: number;
+}
+
+export interface RunResultSummary {
+  runId?: string;
+  lines: RunLineResult[];
+  checkoutHandoffReached: boolean;
+  handoffMessage?: string;
+}

--- a/tests/run/formatRunSummary.spec.ts
+++ b/tests/run/formatRunSummary.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+import { formatRunSummaryHuman } from '../../src/run/formatRunSummary';
+import type { RunResultSummary } from '../../src/run/runTypes';
+
+test('formatRunSummaryHuman surfaces review_needed before other lines', () => {
+  const summary: RunResultSummary = {
+    runId: 'run-test',
+    checkoutHandoffReached: false,
+    handoffMessage: 'Checkout handoff was not requested.',
+    lines: [
+      { lineId: '1', outcome: 'added', userMessage: 'ok', barboraLabel: 'A', quantityAdded: 1 },
+      { lineId: '2', outcome: 'review_needed', userMessage: 'check Barbora' },
+    ],
+  };
+  const text = formatRunSummaryHuman(summary);
+  expect(text).toContain('Needs attention (1 line(s)):');
+  expect(text.indexOf('Needs attention')).toBeLessThan(text.indexOf('Line outcomes:'));
+  expect(text).toContain('lineId: 2');
+  expect(text).toContain('Checkout handoff: no');
+});


### PR DESCRIPTION
## What changed
- Added a first end-to-end cart preparation orchestration flow
- Added run summary types and a human-readable formatter
- Added a CLI entrypoint for cart-prep runs
- Added a small formatter test
- Added an npm script for running the cart-prep flow

## Why
This connects the previously validated spikes into one small vertical slice that can:
- process one or more shopping inputs
- search for candidates
- choose a simple candidate
- add products to cart
- optionally attempt checkout handoff
- emit a run summary

## Notes
- This is still an MVP-oriented orchestration slice, not a full intelligent agent
- Candidate selection remains intentionally naive
- Outcomes currently focus on `added`, `skipped`, and `review_needed`
- Checkout handoff remains opt-in and payment is never automated
