### PR TITLE
feat: add known mapping persistence workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Cursor IDE (local settings, plans, MCP cache)
+.cursor/
+
 # Local secrets and env (never commit)
 .env
 
@@ -5,6 +8,9 @@
 .auth/
 
 shopping.txt
+
+# Local Barbora product memory (created by known-mappings:persist); keep in your working copy, do not commit.
+known-mappings.json
 
 node_modules/
 .auth/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "spike:search": "npx tsx scripts/search-spike.ts",
     "spike:add-to-cart": "npx tsx scripts/add-to-cart-spike.ts",
     "spike:checkout-handoff": "npx tsx scripts/checkout-handoff-spike.ts",
-    "run:cart-prep": "npx tsx scripts/cart-prep-run.ts"
+    "run:cart-prep": "npx tsx scripts/cart-prep-run.ts",
+    "known-mappings:persist": "npx tsx scripts/persist-known-mappings.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.0",

--- a/scripts/persist-known-mappings.ts
+++ b/scripts/persist-known-mappings.ts
@@ -1,0 +1,146 @@
+/**
+ * Persist human-approved cart-prep lines into known-mappings.json (TASK-011).
+ * Requires explicit --lines (comma-separated lineId values). Does not auto-persist every added line.
+ */
+
+import * as path from 'node:path';
+
+import {
+  persistApprovedLinesToKnownMappingsFile,
+} from '../src/mappings/persistKnownMappings';
+
+function printHelp(): void {
+  console.log(`Usage: npx tsx scripts/persist-known-mappings.ts --run <path> --lines <ids> [options]
+
+Read a cart-prep RunResultSummary JSON (--json from cart-prep-run) and merge selected lines into
+known-mappings.json. Only lineIds you list are considered; each must be outcome added and pass checks.
+
+Required:
+  --run <path>           Run summary JSON file
+  --lines <id,id,...>    Comma-separated lineId values from that run (required; no bulk default)
+
+Options:
+  --known-mappings <path>  Output mappings file (default: known-mappings.json in cwd)
+  --dry-run                Print outcomes and merged mappings JSON to stdout; do not write file
+  --include-known-mapping-hits
+                          Allow persisting lines that resolved from known_mapping (default: skip them)
+
+Merge rule: each new mapping replaces the first existing row that shares any normalized match key
+or alias; otherwise it is appended.
+
+Examples:
+  npx tsx scripts/persist-known-mappings.ts --run run.json --lines 2,4
+  npx tsx scripts/persist-known-mappings.ts --run run.json --lines 1 --dry-run
+`);
+}
+
+function parseArgs(argv: string[]): {
+  runPath: string;
+  lineIds: string[];
+  knownMappingsPath: string;
+  dryRun: boolean;
+  includeKnownMappingHits: boolean;
+} {
+  let runPath = '';
+  let linesArg = '';
+  let knownMappingsPath = 'known-mappings.json';
+  let dryRun = false;
+  let includeKnownMappingHits = false;
+  const rest = [...argv];
+  while (rest.length > 0) {
+    const a = rest.shift()!;
+    if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (a === '--run') {
+      runPath = (rest.shift() ?? '').trim();
+      continue;
+    }
+    if (a === '--lines') {
+      linesArg = (rest.shift() ?? '').trim();
+      continue;
+    }
+    if (a === '--known-mappings') {
+      knownMappingsPath = (rest.shift() ?? '').trim();
+      if (!knownMappingsPath) {
+        console.error('[persist-known-mappings] --known-mappings requires a path');
+        process.exit(1);
+      }
+      continue;
+    }
+    if (a === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (a === '--include-known-mapping-hits') {
+      includeKnownMappingHits = true;
+      continue;
+    }
+    console.error(`[persist-known-mappings] unknown argument: ${a}`);
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!runPath) {
+    console.error('[persist-known-mappings] missing required --run <path>');
+    printHelp();
+    process.exit(1);
+  }
+  if (!linesArg) {
+    console.error('[persist-known-mappings] missing required --lines <id,id,...>');
+    printHelp();
+    process.exit(1);
+  }
+
+  const lineIds = linesArg
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  if (lineIds.length === 0) {
+    console.error('[persist-known-mappings] --lines must list at least one non-empty lineId');
+    process.exit(1);
+  }
+
+  return { runPath, lineIds, knownMappingsPath, dryRun, includeKnownMappingHits };
+}
+
+function main(): void {
+  const { runPath, lineIds, knownMappingsPath, dryRun, includeKnownMappingHits } = parseArgs(
+    process.argv.slice(2),
+  );
+
+  try {
+    const { outcomes, written, mergedMappings } = persistApprovedLinesToKnownMappingsFile({
+      runJsonPath: path.resolve(process.cwd(), runPath),
+      knownMappingsPath: path.resolve(process.cwd(), knownMappingsPath),
+      approvedLineIds: lineIds,
+      dryRun,
+      includeKnownMappingHits,
+    });
+
+    for (const o of outcomes) {
+      if (o.status === 'persisted') {
+        console.log(`lineId ${o.lineId}: persisted`);
+      } else {
+        console.error(`lineId ${o.lineId}: skipped — ${o.reason ?? 'unknown'}`);
+      }
+    }
+
+    if (dryRun) {
+      console.log('\nMerged mappings (dry-run, not written):');
+      console.log(JSON.stringify({ mappings: mergedMappings }, null, 2));
+    } else if (written) {
+      console.log(`\nWrote ${knownMappingsPath}`);
+    } else {
+      console.log('\nNo mapping file write (dry-run or no eligible lines to persist).');
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[persist-known-mappings] ${msg}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/persist-known-mappings.ts
+++ b/scripts/persist-known-mappings.ts
@@ -14,6 +14,7 @@ function printHelp(): void {
 
 Read a cart-prep RunResultSummary JSON (--json from cart-prep-run) and merge selected lines into
 known-mappings.json. Only lineIds you list are considered; each must be outcome added and pass checks.
+Run files may be UTF-8 (with or without BOM) or UTF-16 LE/BE with BOM (common when saved from Windows).
 
 Required:
   --run <path>           Run summary JSON file

--- a/src/mappings/knownMappings.ts
+++ b/src/mappings/knownMappings.ts
@@ -1,6 +1,6 @@
 /**
- * Read-only known Barbora product mappings (known-mappings.json).
- * Persistence / save flows are future work (TASK-011).
+ * Known Barbora product mappings (known-mappings.json): load, lookup, and parse validation.
+ * Writes are performed only by `persistKnownMappings.ts` (explicit CLI approval workflow).
  */
 
 import * as fs from 'node:fs';

--- a/src/mappings/persistKnownMappings.ts
+++ b/src/mappings/persistKnownMappings.ts
@@ -1,0 +1,234 @@
+/**
+ * Merge approved cart-prep lines into known-mappings.json (TASK-011).
+ *
+ * Merge rule: for each new entry in order, if any normalized matchKey or alias collides with any
+ * normalized key on an existing entry, replace the first such existing row; otherwise append.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { validateBarboraProductUrl } from '../barbora/validateBarboraProductUrl';
+import { normalizeForMatch } from '../resolver/normalizeForMatch';
+import type { RunLineResult, RunResultSummary } from '../run/runTypes';
+import type { KnownBarboraProductMappingEntry } from './knownMappings';
+import { loadKnownMappingsFromFile } from './knownMappings';
+
+export interface PersistLineOutcome {
+  lineId: string;
+  status: 'persisted' | 'skipped';
+  reason?: string;
+}
+
+function normalizedKeySet(entry: KnownBarboraProductMappingEntry): Set<string> {
+  const set = new Set<string>();
+  for (const k of [...entry.matchKeys, ...entry.aliases]) {
+    const n = normalizeForMatch(k);
+    if (n.length > 0) set.add(n);
+  }
+  return set;
+}
+
+/** True if any normalized match key or alias overlaps between the two entries. */
+export function entriesNormalizedKeysCollide(
+  a: KnownBarboraProductMappingEntry,
+  b: KnownBarboraProductMappingEntry,
+): boolean {
+  const sa = normalizedKeySet(a);
+  const sb = normalizedKeySet(b);
+  for (const x of sa) {
+    if (sb.has(x)) return true;
+  }
+  return false;
+}
+
+/**
+ * Applies incoming entries in order: each replaces the first existing entry that collides on normalized
+ * keys, or is appended.
+ */
+export function mergeKnownMappingEntries(
+  existing: KnownBarboraProductMappingEntry[],
+  incoming: KnownBarboraProductMappingEntry[],
+): KnownBarboraProductMappingEntry[] {
+  const out = [...existing];
+  for (const neu of incoming) {
+    const idx = out.findIndex((e) => entriesNormalizedKeysCollide(e, neu));
+    if (idx >= 0) out[idx] = neu;
+    else out.push(neu);
+  }
+  return out;
+}
+
+export function parseRunResultSummaryJson(parsed: unknown): RunResultSummary | null {
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const o = parsed as Record<string, unknown>;
+  if (!Array.isArray(o.lines)) return null;
+  if (typeof o.checkoutHandoffReached !== 'boolean') return null;
+
+  const lines: RunLineResult[] = [];
+  for (const row of o.lines) {
+    if (row === null || typeof row !== 'object') return null;
+    const r = row as Record<string, unknown>;
+    if (typeof r.lineId !== 'string' || typeof r.outcome !== 'string' || typeof r.userMessage !== 'string') {
+      return null;
+    }
+    if (r.outcome !== 'added' && r.outcome !== 'skipped' && r.outcome !== 'review_needed') return null;
+    lines.push(r as unknown as RunLineResult);
+  }
+
+  return {
+    runId: typeof o.runId === 'string' ? o.runId : undefined,
+    lines,
+    checkoutHandoffReached: o.checkoutHandoffReached,
+    handoffMessage: typeof o.handoffMessage === 'string' ? o.handoffMessage : undefined,
+  };
+}
+
+export function dedupeApprovedLineIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of ids) {
+    const t = raw.trim();
+    if (t.length === 0 || seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+  }
+  return out;
+}
+
+export function mappingEntryFromApprovedLine(
+  line: RunLineResult,
+  options: { includeKnownMappingHits: boolean },
+): { ok: true; entry: KnownBarboraProductMappingEntry } | { ok: false; reason: string } {
+  if (line.outcome !== 'added') {
+    return { ok: false, reason: `outcome is "${line.outcome}", expected added` };
+  }
+  if (line.resolutionSource === 'known_mapping' && !options.includeKnownMappingHits) {
+    return {
+      ok: false,
+      reason: 'resolutionSource is known_mapping (pass --include-known-mapping-hits to persist)',
+    };
+  }
+  const query = line.query?.trim() ?? '';
+  if (query.length === 0) {
+    return {
+      ok: false,
+      reason: 'missing query on run line (re-run cart-prep with a build that records query on each line)',
+    };
+  }
+  const label = line.barboraLabel?.trim() ?? '';
+  if (label.length === 0) {
+    return { ok: false, reason: 'missing barboraLabel' };
+  }
+  const rawRef = line.barboraProductRef?.trim() ?? '';
+  if (rawRef.length === 0) {
+    return { ok: false, reason: 'missing barboraProductRef (re-run cart-prep with a build that records product URLs)' };
+  }
+  const urlCheck = validateBarboraProductUrl(rawRef);
+  if (!urlCheck.ok) {
+    return { ok: false, reason: `invalid barboraProductRef: ${urlCheck.message}` };
+  }
+  return {
+    ok: true,
+    entry: {
+      matchKeys: [query],
+      aliases: [],
+      barboraProductRef: urlCheck.productUrl,
+      displayName: label,
+    },
+  };
+}
+
+export function collectApprovedMappingEntries(
+  summary: RunResultSummary,
+  approvedLineIds: string[],
+  options: { includeKnownMappingHits: boolean },
+): { entries: KnownBarboraProductMappingEntry[]; outcomes: PersistLineOutcome[] } {
+  const ids = dedupeApprovedLineIds(approvedLineIds);
+  const idToLine = new Map(summary.lines.map((l) => [l.lineId, l]));
+  const entries: KnownBarboraProductMappingEntry[] = [];
+  const outcomes: PersistLineOutcome[] = [];
+
+  for (const id of ids) {
+    const line = idToLine.get(id);
+    if (line == null) {
+      outcomes.push({ lineId: id, status: 'skipped', reason: 'no line with this lineId in run summary' });
+      continue;
+    }
+    const built = mappingEntryFromApprovedLine(line, options);
+    if (!built.ok) {
+      outcomes.push({ lineId: id, status: 'skipped', reason: built.reason });
+      continue;
+    }
+    entries.push(built.entry);
+    outcomes.push({ lineId: id, status: 'persisted' });
+  }
+
+  return { entries, outcomes };
+}
+
+export function writeKnownMappingsStoreAtomic(filePath: string, store: { mappings: KnownBarboraProductMappingEntry[] }): void {
+  const resolved = path.resolve(filePath);
+  const dir = path.dirname(resolved);
+  const payload = `${JSON.stringify(store, null, 2)}\n`;
+  const tmp = path.join(dir, `.known-mappings.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`);
+  fs.writeFileSync(tmp, payload, 'utf8');
+  try {
+    fs.renameSync(tmp, resolved);
+  } catch {
+    try {
+      fs.unlinkSync(resolved);
+    } catch {
+      /* ignore */
+    }
+    fs.renameSync(tmp, resolved);
+  }
+}
+
+export interface PersistToKnownMappingsFileOptions {
+  runJsonPath: string;
+  knownMappingsPath: string;
+  approvedLineIds: string[];
+  dryRun: boolean;
+  includeKnownMappingHits: boolean;
+}
+
+export function persistApprovedLinesToKnownMappingsFile(
+  options: PersistToKnownMappingsFileOptions,
+): { outcomes: PersistLineOutcome[]; written: boolean; mergedMappings: KnownBarboraProductMappingEntry[] } {
+  const resolvedRun = path.resolve(options.runJsonPath);
+  let text: string;
+  try {
+    text = fs.readFileSync(resolvedRun, 'utf8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`cannot read run file (${resolvedRun}): ${msg}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`invalid JSON in run file (${resolvedRun}): ${msg}`);
+  }
+  const summary = parseRunResultSummaryJson(parsed);
+  if (summary == null) {
+    throw new Error(`run file is not a valid RunResultSummary (${resolvedRun})`);
+  }
+
+  const { entries, outcomes } = collectApprovedMappingEntries(summary, options.approvedLineIds, {
+    includeKnownMappingHits: options.includeKnownMappingHits,
+  });
+
+  const resolvedMappingsPath = path.resolve(options.knownMappingsPath);
+  const prior = loadKnownMappingsFromFile(resolvedMappingsPath);
+  const mergedMappings = mergeKnownMappingEntries(prior.mappings, entries);
+
+  const shouldWrite = !options.dryRun && entries.length > 0;
+  if (shouldWrite) {
+    writeKnownMappingsStoreAtomic(resolvedMappingsPath, { mappings: mergedMappings });
+  }
+
+  return { outcomes, written: shouldWrite, mergedMappings };
+}

--- a/src/mappings/persistKnownMappings.ts
+++ b/src/mappings/persistKnownMappings.ts
@@ -11,6 +11,8 @@ import * as path from 'node:path';
 
 import { validateBarboraProductUrl } from '../barbora/validateBarboraProductUrl';
 import { normalizeForMatch } from '../resolver/normalizeForMatch';
+import { readTextFileAutodetect } from '../text/readTextFileAutodetect';
+import { transliterateLatvianToAscii } from '../text/transliterateLatvianToAscii';
 import type { RunLineResult, RunResultSummary } from '../run/runTypes';
 import type { KnownBarboraProductMappingEntry } from './knownMappings';
 import { loadKnownMappingsFromFile } from './knownMappings';
@@ -129,13 +131,15 @@ export function mappingEntryFromApprovedLine(
   if (!urlCheck.ok) {
     return { ok: false, reason: `invalid barboraProductRef: ${urlCheck.message}` };
   }
+  const keyAscii = transliterateLatvianToAscii(query);
+  const displayAscii = transliterateLatvianToAscii(label);
   return {
     ok: true,
     entry: {
-      matchKeys: [query],
+      matchKeys: [keyAscii],
       aliases: [],
       barboraProductRef: urlCheck.productUrl,
-      displayName: label,
+      displayName: displayAscii,
     },
   };
 }
@@ -200,7 +204,7 @@ export function persistApprovedLinesToKnownMappingsFile(
   const resolvedRun = path.resolve(options.runJsonPath);
   let text: string;
   try {
-    text = fs.readFileSync(resolvedRun, 'utf8');
+    text = readTextFileAutodetect(resolvedRun);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(`cannot read run file (${resolvedRun}): ${msg}`);

--- a/src/resolver/normalizeForMatch.ts
+++ b/src/resolver/normalizeForMatch.ts
@@ -1,8 +1,11 @@
+import { transliterateLatvianToAscii } from '../text/transliterateLatvianToAscii';
+
 /**
  * Shared text normalization for resolver scoring and known-mapping key lookup.
+ * Latvian diacritics are folded to ASCII first so list lines and Barbora titles match reliably.
  */
 export function normalizeForMatch(text: string): string {
-  return text
+  return transliterateLatvianToAscii(text)
     .trim()
     .toLowerCase()
     .replace(/[^\p{L}\p{M}\p{N}\s]/gu, ' ')

--- a/src/run/cartPrepRun.ts
+++ b/src/run/cartPrepRun.ts
@@ -195,12 +195,15 @@ export async function runCartPrepRun(
                 productUrl: picked.productUrl,
               });
               const addMsg = `${USER_MESSAGE_ADD_FROM_LLM_FALLBACK} ${addResult.message}`.trim();
+              const llmUrlCheck = validateBarboraProductUrl(picked.productUrl);
               lineResults.push({
                 lineId: line.lineId,
+                query: q,
                 outcome: 'added',
                 resolutionSource: 'llm_fallback',
                 barboraLabel: picked.title,
                 quantityAdded: 1,
+                ...(llmUrlCheck.ok ? { barboraProductRef: llmUrlCheck.productUrl } : {}),
                 userMessage: mappingFallbackNote ? `${mappingFallbackNote} ${addMsg}` : addMsg,
                 lineDebug: lineDebugBase(includeDebug, {
                   knownMappingHit,
@@ -227,6 +230,7 @@ export async function runCartPrepRun(
         const userMessage = [mappingFallbackNote, reviewText].filter(Boolean).join(' ');
         lineResults.push({
           lineId: line.lineId,
+          query: q,
           outcome: 'review_needed',
           userMessage,
           reviewReasonCode: resolved.reasonCode,
@@ -255,12 +259,16 @@ export async function runCartPrepRun(
       const llmOutcomeForAdd: LlmDebugOutcome =
         options.llmResolve == null ? 'not_configured' : 'skipped_ineligible';
 
+      const addUrlCheck = validateBarboraProductUrl(resolved.candidate.productUrl);
+
       lineResults.push({
         lineId: line.lineId,
+        query: q,
         outcome: 'added',
         resolutionSource: resolvedFromKnownMapping ? 'known_mapping' : 'deterministic',
         barboraLabel: resolved.candidate.title,
         quantityAdded: 1,
+        ...(addUrlCheck.ok ? { barboraProductRef: addUrlCheck.productUrl } : {}),
         userMessage: mappingFallbackNote ? `${mappingFallbackNote} ${addMsg}` : addMsg,
         lineDebug: lineDebugBase(includeDebug, {
           knownMappingHit,
@@ -277,6 +285,7 @@ export async function runCartPrepRun(
       const msg = e instanceof Error ? e.message : String(e);
       lineResults.push({
         lineId: line.lineId,
+        query: q,
         outcome: outcomeFromSearchFailure(msg),
         userMessage: msg,
         lineDebug: lineDebugBase(includeDebug, {

--- a/src/run/cartPrepRun.ts
+++ b/src/run/cartPrepRun.ts
@@ -14,6 +14,7 @@ import {
 } from '../llm';
 import { findMappingForNormalizedQuery, loadKnownMappingsFromFile } from '../mappings/knownMappings';
 import { normalizeForMatch } from '../resolver/normalizeForMatch';
+import { transliterateLatvianToAscii } from '../text/transliterateLatvianToAscii';
 import type { ShoppingLineResolverDebug } from '../resolver/resolveShoppingLine';
 import { resolveShoppingLine } from '../resolver/resolveShoppingLine';
 import { llmDebugBeforeLlmCall } from './llmLineDebug';
@@ -84,6 +85,15 @@ function resolverDebugToLineFields(
 function lineDebugBase(includeDebug: boolean, partial: LineResolutionDebug): LineResolutionDebug | undefined {
   if (!includeDebug) return undefined;
   return partial;
+}
+
+/** ASCII-friendly strings for run JSON (search still uses the raw query). */
+function summaryQuery(q: string): string {
+  return transliterateLatvianToAscii(q);
+}
+
+function summaryLabel(title: string): string {
+  return transliterateLatvianToAscii(title);
 }
 
 /**
@@ -198,10 +208,10 @@ export async function runCartPrepRun(
               const llmUrlCheck = validateBarboraProductUrl(picked.productUrl);
               lineResults.push({
                 lineId: line.lineId,
-                query: q,
+                query: summaryQuery(q),
                 outcome: 'added',
                 resolutionSource: 'llm_fallback',
-                barboraLabel: picked.title,
+                barboraLabel: summaryLabel(picked.title),
                 quantityAdded: 1,
                 ...(llmUrlCheck.ok ? { barboraProductRef: llmUrlCheck.productUrl } : {}),
                 userMessage: mappingFallbackNote ? `${mappingFallbackNote} ${addMsg}` : addMsg,
@@ -230,7 +240,7 @@ export async function runCartPrepRun(
         const userMessage = [mappingFallbackNote, reviewText].filter(Boolean).join(' ');
         lineResults.push({
           lineId: line.lineId,
-          query: q,
+          query: summaryQuery(q),
           outcome: 'review_needed',
           userMessage,
           reviewReasonCode: resolved.reasonCode,
@@ -263,10 +273,10 @@ export async function runCartPrepRun(
 
       lineResults.push({
         lineId: line.lineId,
-        query: q,
+        query: summaryQuery(q),
         outcome: 'added',
         resolutionSource: resolvedFromKnownMapping ? 'known_mapping' : 'deterministic',
-        barboraLabel: resolved.candidate.title,
+        barboraLabel: summaryLabel(resolved.candidate.title),
         quantityAdded: 1,
         ...(addUrlCheck.ok ? { barboraProductRef: addUrlCheck.productUrl } : {}),
         userMessage: mappingFallbackNote ? `${mappingFallbackNote} ${addMsg}` : addMsg,
@@ -285,7 +295,7 @@ export async function runCartPrepRun(
       const msg = e instanceof Error ? e.message : String(e);
       lineResults.push({
         lineId: line.lineId,
-        query: q,
+        query: summaryQuery(q),
         outcome: outcomeFromSearchFailure(msg),
         userMessage: msg,
         lineDebug: lineDebugBase(includeDebug, {

--- a/src/run/reviewReasonUserMessages.ts
+++ b/src/run/reviewReasonUserMessages.ts
@@ -23,4 +23,4 @@ export const USER_MESSAGE_ADD_FROM_SEARCH = 'Best match from your search; added 
 
 /** Shown when the deterministic resolver could not decide and an LLM fallback chose a candidate. */
 export const USER_MESSAGE_ADD_FROM_LLM_FALLBACK =
-  'LLM picked among similar search results; added to cart — verify on Barbora if unsure.';
+  'LLM picked among similar search results; added to cart - verify on Barbora if unsure.';

--- a/src/run/runTypes.ts
+++ b/src/run/runTypes.ts
@@ -45,7 +45,7 @@ export interface RunLineResult {
   lineId: string;
   outcome: LineOutcome;
   userMessage: string;
-  /** Shopping-line search text (trimmed); set when the line had non-empty query after trim. */
+  /** Shopping-line search text (trimmed); ASCII transliteration of Latvian letters for stable JSON. */
   query?: string;
   barboraLabel?: string;
   quantityAdded?: number;

--- a/src/run/runTypes.ts
+++ b/src/run/runTypes.ts
@@ -45,8 +45,12 @@ export interface RunLineResult {
   lineId: string;
   outcome: LineOutcome;
   userMessage: string;
+  /** Shopping-line search text (trimmed); set when the line had non-empty query after trim. */
+  query?: string;
   barboraLabel?: string;
   quantityAdded?: number;
+  /** Canonical Barbora product URL when outcome is added and URL was validated for add-to-cart. */
+  barboraProductRef?: string;
   /** Set only when outcome is added; which path selected the product. */
   resolutionSource?: ResolutionSource;
   /** Set only when outcome is review_needed from the deterministic resolver (not search/executor errors). */

--- a/src/text/readTextFileAutodetect.ts
+++ b/src/text/readTextFileAutodetect.ts
@@ -1,0 +1,30 @@
+import * as fs from 'node:fs';
+
+/**
+ * Reads text from disk with encoding autodetection.
+ * Windows editors often save JSON as UTF-16 LE; reading those as UTF-8 yields mojibake and JSON.parse fails.
+ * Also strips UTF-8 BOM when present.
+ */
+export function readTextFileAutodetect(filePath: string): string {
+  const buf = fs.readFileSync(filePath);
+
+  if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe) {
+    return buf.toString('utf16le').replace(/^\uFEFF/, '');
+  }
+
+  if (buf.length >= 2 && buf[0] === 0xfe && buf[1] === 0xff) {
+    const body = buf.subarray(2);
+    const swapped = Buffer.alloc(body.length);
+    for (let i = 0; i + 1 < body.length; i += 2) {
+      swapped[i] = body[i + 1]!;
+      swapped[i + 1] = body[i]!;
+    }
+    return swapped.toString('utf16le').replace(/^\uFEFF/, '');
+  }
+
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) {
+    return buf.subarray(3).toString('utf8');
+  }
+
+  return buf.toString('utf8');
+}

--- a/src/text/transliterateLatvianToAscii.ts
+++ b/src/text/transliterateLatvianToAscii.ts
@@ -1,0 +1,43 @@
+/**
+ * Maps Latvian letters (and common Latvian-style Latin diacritics) to similar ASCII letters.
+ * Used so JSON files and normalized match keys avoid mojibake-prone UTF-8 in constrained tooling,
+ * while keeping resolver / known-mapping lookup consistent.
+ *
+ * Latvian alphabet: A Ā B C Č D E Ē F G Ģ H I Ī J K Ķ L Ļ M N Ņ O P R S Š T U Ū V Z Ž
+ */
+
+const LATVIAN_TO_ASCII: Readonly<Record<string, string>> = {
+  Ā: 'A',
+  ā: 'a',
+  Č: 'C',
+  č: 'c',
+  Ē: 'E',
+  ē: 'e',
+  Ģ: 'G',
+  ģ: 'g',
+  Ī: 'I',
+  ī: 'i',
+  Ķ: 'K',
+  ķ: 'k',
+  Ļ: 'L',
+  ļ: 'l',
+  Ņ: 'N',
+  ņ: 'n',
+  Š: 'S',
+  š: 's',
+  Ū: 'U',
+  ū: 'u',
+  Ž: 'Z',
+  ž: 'z',
+};
+
+/**
+ * Replaces Latvian-specific letters with ASCII lookalikes; leaves other code points unchanged.
+ */
+export function transliterateLatvianToAscii(text: string): string {
+  let out = '';
+  for (const ch of text) {
+    out += LATVIAN_TO_ASCII[ch] ?? ch;
+  }
+  return out;
+}

--- a/tests/mappings/knownMappings.spec.ts
+++ b/tests/mappings/knownMappings.spec.ts
@@ -87,3 +87,22 @@ test('findMappingForNormalizedQuery returns null when no match', () => {
   const store = { mappings: [] };
   expect(findMappingForNormalizedQuery(store, 'piens')).toBeNull();
 });
+
+test('findMappingForNormalizedQuery matches Latvian matchKey to ASCII-normalized query', () => {
+  const store = loadKnownMappingsFromFile(
+    writeTempJson(
+      'm.json',
+      JSON.stringify({
+        mappings: [
+          {
+            matchKeys: ['piēns 2l'],
+            aliases: [],
+            barboraProductRef: 'https://www.barbora.lv/produkti/piens',
+          },
+        ],
+      }),
+    ),
+  );
+  const n = normalizeForMatch('piens 2l');
+  expect(findMappingForNormalizedQuery(store, n)?.barboraProductRef).toContain('/piens');
+});

--- a/tests/mappings/persistKnownMappings.spec.ts
+++ b/tests/mappings/persistKnownMappings.spec.ts
@@ -1,0 +1,205 @@
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import { loadKnownMappingsFromFile } from '../../src/mappings/knownMappings';
+import {
+  collectApprovedMappingEntries,
+  dedupeApprovedLineIds,
+  mappingEntryFromApprovedLine,
+  mergeKnownMappingEntries,
+  parseRunResultSummaryJson,
+  persistApprovedLinesToKnownMappingsFile,
+} from '../../src/mappings/persistKnownMappings';
+import type { RunResultSummary } from '../../src/run/runTypes';
+
+const BAR = 'https://www.barbora.lv/produkti/test-product';
+
+function writeTempJson(name: string, content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'barbora-persist-'));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+function minimalSummary(lines: RunResultSummary['lines']): RunResultSummary {
+  return {
+    runId: 'run-test',
+    lines,
+    checkoutHandoffReached: false,
+    handoffMessage: 'x',
+  };
+}
+
+test('mergeKnownMappingEntries appends when no key collision', () => {
+  const a = { matchKeys: ['piens'], aliases: [] as string[], barboraProductRef: `${BAR}-a` };
+  const b = { matchKeys: ['maize'], aliases: [] as string[], barboraProductRef: `${BAR}-b` };
+  expect(mergeKnownMappingEntries([a], [b])).toEqual([a, b]);
+});
+
+test('mergeKnownMappingEntries replaces first colliding entry', () => {
+  const oldRow = { matchKeys: ['Piens 2l'], aliases: [] as string[], barboraProductRef: `${BAR}-old` };
+  const other = { matchKeys: ['maize'], aliases: [] as string[], barboraProductRef: `${BAR}-other` };
+  const neu = {
+    matchKeys: ['piens 2l'],
+    aliases: [] as string[],
+    barboraProductRef: `${BAR}-new`,
+    displayName: 'New',
+  };
+  const merged = mergeKnownMappingEntries([oldRow, other], [neu]);
+  expect(merged).toHaveLength(2);
+  expect(merged[0]).toEqual(neu);
+  expect(merged[1]).toEqual(other);
+});
+
+test('mergeKnownMappingEntries second incoming collides with first incoming after it was appended', () => {
+  const existing = [{ matchKeys: ['x'], aliases: [] as string[], barboraProductRef: `${BAR}-x` }];
+  const first = { matchKeys: ['a'], aliases: [] as string[], barboraProductRef: `${BAR}-a` };
+  const second = { matchKeys: ['a'], aliases: [] as string[], barboraProductRef: `${BAR}-a2` };
+  const merged = mergeKnownMappingEntries(existing, [first, second]);
+  expect(merged.map((m) => m.barboraProductRef)).toEqual([`${BAR}-x`, `${BAR}-a2`]);
+});
+
+test('mappingEntryFromApprovedLine skips known_mapping unless flag', () => {
+  const line = {
+    lineId: '1',
+    outcome: 'added' as const,
+    userMessage: 'ok',
+    query: 'piens',
+    barboraLabel: 'T',
+    barboraProductRef: BAR,
+    resolutionSource: 'known_mapping' as const,
+  };
+  expect(mappingEntryFromApprovedLine(line, { includeKnownMappingHits: false }).ok).toBe(false);
+  const withFlag = mappingEntryFromApprovedLine(line, { includeKnownMappingHits: true });
+  expect(withFlag.ok).toBe(true);
+  if (withFlag.ok) {
+    expect(withFlag.entry.matchKeys).toEqual(['piens']);
+    expect(withFlag.entry.barboraProductRef).toBe(BAR);
+  }
+});
+
+test('collectApprovedMappingEntries respects eligibility', () => {
+  const summary = minimalSummary([
+    {
+      lineId: '1',
+      outcome: 'added',
+      userMessage: 'ok',
+      query: 'q1',
+      barboraLabel: 'L1',
+      barboraProductRef: BAR,
+      resolutionSource: 'deterministic',
+    },
+    {
+      lineId: '2',
+      outcome: 'review_needed',
+      userMessage: 'check',
+      query: 'q2',
+    },
+  ]);
+  const { entries, outcomes } = collectApprovedMappingEntries(summary, ['1', '2', '99'], {
+    includeKnownMappingHits: false,
+  });
+  expect(entries).toHaveLength(1);
+  expect(outcomes).toHaveLength(3);
+  expect(outcomes[0]?.status).toBe('persisted');
+  expect(outcomes[1]?.status).toBe('skipped');
+  expect(outcomes[2]?.status).toBe('skipped');
+});
+
+test('dedupeApprovedLineIds preserves first occurrence order', () => {
+  expect(dedupeApprovedLineIds([' 2 ', '1', '2', '1'])).toEqual(['2', '1']);
+});
+
+test('parseRunResultSummaryJson rejects invalid root', () => {
+  expect(parseRunResultSummaryJson(null)).toBeNull();
+  expect(parseRunResultSummaryJson({ lines: [] })).toBeNull();
+  expect(parseRunResultSummaryJson({ lines: [], checkoutHandoffReached: true })).not.toBeNull();
+});
+
+test('persistApprovedLinesToKnownMappingsFile dryRun does not write', () => {
+  const runPath = writeTempJson(
+    'run.json',
+    JSON.stringify(
+      minimalSummary([
+        {
+          lineId: '1',
+          outcome: 'added',
+          userMessage: 'ok',
+          query: 'piens',
+          barboraLabel: 'Tere',
+          barboraProductRef: BAR,
+          resolutionSource: 'deterministic',
+        },
+      ]),
+    ),
+  );
+  const dir = path.dirname(runPath);
+  const km = path.join(dir, 'known-mappings.json');
+  const { written } = persistApprovedLinesToKnownMappingsFile({
+    runJsonPath: runPath,
+    knownMappingsPath: km,
+    approvedLineIds: ['1'],
+    dryRun: true,
+    includeKnownMappingHits: false,
+  });
+  expect(written).toBe(false);
+  expect(fs.existsSync(km)).toBe(false);
+});
+
+test('persistApprovedLinesToKnownMappingsFile writes and loadKnownMappingsFromFile accepts', () => {
+  const runPath = writeTempJson(
+    'run.json',
+    JSON.stringify(
+      minimalSummary([
+        {
+          lineId: '1',
+          outcome: 'added',
+          userMessage: 'ok',
+          query: 'piens 2l',
+          barboraLabel: 'Tere piens',
+          barboraProductRef: BAR,
+          resolutionSource: 'deterministic',
+        },
+      ]),
+    ),
+  );
+  const dir = path.dirname(runPath);
+  const km = path.join(dir, 'known-mappings.json');
+
+  const { written } = persistApprovedLinesToKnownMappingsFile({
+    runJsonPath: runPath,
+    knownMappingsPath: km,
+    approvedLineIds: ['1'],
+    dryRun: false,
+    includeKnownMappingHits: false,
+  });
+  expect(written).toBe(true);
+
+  const store = loadKnownMappingsFromFile(km);
+  expect(store.mappings).toHaveLength(1);
+  expect(store.mappings[0]!.matchKeys).toEqual(['piens 2l']);
+  expect(store.mappings[0]!.displayName).toBe('Tere piens');
+});
+
+test('persist CLI exits non-zero when --lines is missing', () => {
+  const repoRoot = path.join(__dirname, '..', '..');
+  const script = path.join(repoRoot, 'scripts', 'persist-known-mappings.ts');
+  const tmpRun = writeTempJson('run.json', JSON.stringify(minimalSummary([])));
+  let exited = false;
+  try {
+    execSync(`npx tsx "${script}" --run "${tmpRun}"`, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+  } catch (e: unknown) {
+    exited = true;
+    const err = e as { status: number | null };
+    expect(err.status).toBe(1);
+  }
+  expect(exited).toBe(true);
+});

--- a/tests/text/readTextFileAutodetect.spec.ts
+++ b/tests/text/readTextFileAutodetect.spec.ts
@@ -1,0 +1,30 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import { readTextFileAutodetect } from '../../src/text/readTextFileAutodetect';
+
+test('readTextFileAutodetect reads UTF-16 LE with BOM (Windows “Unicode”)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'barbora-encoding-'));
+  const p = path.join(dir, 'run.json');
+  const json = '{"a":1}';
+  const buf = Buffer.alloc(2 + json.length * 2);
+  buf.writeUInt16LE(0xfeff, 0);
+  for (let i = 0; i < json.length; i++) {
+    buf.writeUInt16LE(json.charCodeAt(i), 2 + i * 2);
+  }
+  fs.writeFileSync(p, buf);
+
+  expect(readTextFileAutodetect(p)).toBe(json);
+});
+
+test('readTextFileAutodetect reads UTF-8 with BOM', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'barbora-encoding-'));
+  const p = path.join(dir, 'x.json');
+  const body = Buffer.from('{"x":true}', 'utf8');
+  fs.writeFileSync(p, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), body]));
+
+  expect(readTextFileAutodetect(p)).toBe('{"x":true}');
+});

--- a/tests/text/transliterateLatvianToAscii.spec.ts
+++ b/tests/text/transliterateLatvianToAscii.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+import { normalizeForMatch } from '../../src/resolver/normalizeForMatch';
+import { transliterateLatvianToAscii } from '../../src/text/transliterateLatvianToAscii';
+
+test('transliterateLatvianToAscii maps Latvian letters to ASCII', () => {
+  expect(transliterateLatvianToAscii('Āā Čč Ēē Ģģ Īī Ķķ Ļļ Ņņ Šš Ūū Žž')).toBe(
+    'Aa Cc Ee Gg Ii Kk Ll Nn Ss Uu Zz',
+  );
+});
+
+test('normalizeForMatch folds Latvian so equivalent intents match', () => {
+  const a = normalizeForMatch('piens 2l');
+  const b = normalizeForMatch('piēns 2l');
+  expect(a).toBe(b);
+});


### PR DESCRIPTION
## What changed
- Added `query` and `barboraProductRef` fields to run results for persistence workflows
- Added a file-based known-mapping persistence core with deterministic merge behavior
- Added a CLI for persisting explicitly approved line IDs into `known-mappings.json`
- Added dry-run support and atomic file writing for safer local updates
- Added tests covering merge, eligibility, parsing, and CLI behavior

## Why
This closes the first practical learning loop by allowing approved successful choices from prior runs to be persisted into known mappings and reused automatically in future runs.

## Notes
- Persistence remains explicitly human-approved via selected line IDs
- `known_mapping` hits are skipped by default unless explicitly included
- The workflow is local, inspectable, and file-based
- No payment or checkout behavior was changed
